### PR TITLE
Support of modifiable undoable commands within tree histories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,7 +78,7 @@ export default [...[].concat(
             "sort-imports": "off",
             "no-magic-numbers": "off",
             "indent": "off",
-            "multiline-comment-style": ["error", "starred-block"],
+            "multiline-comment-style": "off",
             "arrow-parens": ["error", "as-needed"],
             "complexity": ["error", {
                 max: 10,

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -37,7 +37,7 @@ export function Modifiable(target: unknown, propertyName: string): void {
     target.constructor[INTERACTO_MODIFIABLE] = set;
 }
 
-export function isModifiable(obj: unknown, key: string): boolean {
+export function isCmdModifiable(obj: unknown, key: string): boolean {
     const modifiables: unknown = obj.constructor[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
@@ -46,9 +46,9 @@ export function isModifiable(obj: unknown, key: string): boolean {
     return false;
 }
 
-export function modifyAttributes(obj: unknown, attributes: { [key: string]: unknown }): void {
+export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: unknown }): void {
     Object.keys(attributes).forEach(key => {
-        if (isModifiable(obj, key)) {
+        if (isCmdModifiable(obj, key)) {
             const value: unknown = attributes[key];
             const type = typeof obj[key];
             const typeValue = typeof value;
@@ -67,7 +67,7 @@ export function modifyAttributes(obj: unknown, attributes: { [key: string]: unkn
  * Returns the set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
  * @param obj The object to analyze.
  */
-export function getModifiableAttributes(obj: unknown): Map<string, unknown> {
+export function getModifiableCmdAttributes(obj: unknown): Map<string, unknown> {
     const modifiableAttributes = new Map<string, unknown>();
     const modifiables: unknown = obj.constructor[INTERACTO_MODIFIABLE];
 

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -13,6 +13,7 @@
  */
 import {isUndoableType} from "../undo/Undoable";
 import type {Command} from "./Command";
+import type {Undoable} from "../undo/Undoable";
 
 const INTERACTO_MODIFIABLE: unique symbol = Symbol("interacto-cmd-modifiable");
 
@@ -49,7 +50,7 @@ export function Modifiable(target: unknown, propertyName: string): void {
  * @param key - The property of the command to modify
  * @returns True if the property of the command can be modified.
  */
-export function isCmdModifiable(obj: Command, key: string): boolean {
+export function isCmdModifiable(obj: Command & Undoable, key: string): boolean {
     const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
@@ -63,7 +64,7 @@ export function isCmdModifiable(obj: Command, key: string): boolean {
  * @param obj - The command to modify
  * @param attributes - The set of properties of the command to modify
  */
-export function modifyCmdAttributes<T extends Command>(obj: T, attributes: Partial<T>): void {
+export function modifyCmdAttributes<T extends Command & Undoable>(obj: T, attributes: Partial<T>): void {
     if (!obj.isDone()) {
         // eslint-disable-next-line no-console
         console.error("Only already executed and done Interacto commands can be modified");
@@ -75,7 +76,7 @@ export function modifyCmdAttributes<T extends Command>(obj: T, attributes: Parti
             const tkey = key as keyof T;
             const value = attributes[tkey];
             if (typeof value === typeof obj[tkey]) {
-                obj[tkey] = value as (T & Command)[keyof T];
+                obj[tkey] = value as T[keyof T];
             } else {
                 // eslint-disable-next-line no-console
                 console.error("Trying to affect a value of an incorrect type to a parameter of a command");
@@ -91,22 +92,20 @@ export function modifyCmdAttributes<T extends Command>(obj: T, attributes: Parti
  * @param obj - The object to analyze.
  * @returns The set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
  */
-export function getModifiableCmdAttributes<T>(obj: T & object): Partial<T> {
+export function getModifiableCmdAttributes<T extends Command & Undoable>(obj: T): Partial<T> {
     const modifiableAttributes: Partial<T> = {};
     const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
         for (const key of modifiables) {
             const tkey = key as keyof T;
+            const type = typeof obj[tkey];
 
-            if (typeof tkey === "string" && tkey in obj) {
-                const type = typeof obj[tkey];
-                if (type === "string" || type === "number" || type === "boolean") {
-                    modifiableAttributes[tkey] = obj[tkey];
-                } else {
-                    // eslint-disable-next-line no-console
-                    console.error(type, "Cannot modify a property that is not a string, number, or boolean");
-                }
+            if (type === "string" || type === "number" || type === "boolean") {
+                modifiableAttributes[tkey] = obj[tkey];
+            } else {
+                // eslint-disable-next-line no-console
+                console.error(type, "Cannot modify a property that is not a string, number, or boolean");
             }
         }
     }

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -50,7 +50,7 @@ export function Modifiable(target: unknown, propertyName: string): void {
  * @param key - The property of the command to modify
  * @returns True if the property of the command can be modified.
  */
-export function isCmdModifiable(obj: Command & Undoable, key: string): boolean {
+export function isCmdModifiable(obj: Undoable, key: string): boolean {
     const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
@@ -92,7 +92,7 @@ export function modifyCmdAttributes<T extends Command & Undoable>(obj: T, attrib
  * @param obj - The object to analyze.
  * @returns The set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
  */
-export function getModifiableCmdAttributes<T extends Command & Undoable>(obj: T): Partial<T> {
+export function getModifiableCmdAttributes<T extends Undoable>(obj: T): Partial<T> {
     const modifiableAttributes: Partial<T> = {};
     const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -12,9 +12,9 @@
  * along with Interacto.  If not, see <https://www.gnu.org/licenses/>.
  */
 import {isUndoableType} from "../undo/Undoable";
-import {CommandBase} from "../../impl/command/CommandBase";
+import type {Command} from "./Command";
 
-const INTERACTO_MODIFIABLE: unique symbol = Symbol('interacto-cmd-modifiable');
+const INTERACTO_MODIFIABLE: unique symbol = Symbol("interacto-cmd-modifiable");
 
 interface ModifiableMetadata {
     [INTERACTO_MODIFIABLE]?: Set<string>;
@@ -23,16 +23,17 @@ interface ModifiableMetadata {
 /**
  * The Interacto decorator to mark command's properties as modifiable after being executed.
  * Cannot check the type of the property here (requires reflect-metadata we do not want to install).
- * @param target The targeted command.
- * @param propertyName The name of the property the decorator targets.
+ * @param target - The targeted command.
+ * @param propertyName - The name of the property the decorator targets.
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function Modifiable(target: unknown, propertyName: string): void {
     if (!isUndoableType(target)) {
-        console.log("The @Modifiable decorator currently operates on Interacto undoable commands only")
+        console.log("The @Modifiable decorator currently operates on Interacto undoable commands only");
         return;
     }
 
-    //Getting the object cache related to the modifiable symbol
+    // Getting the object cache related to the modifiable symbol
     const symbolValues: unknown = (target.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
     const set = symbolValues instanceof Set ? symbolValues as Set<string> : new Set<string>();
 
@@ -41,7 +42,13 @@ export function Modifiable(target: unknown, propertyName: string): void {
     (target.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE] = set;
 }
 
-export function isCmdModifiable(obj: CommandBase, key: string): boolean {
+/**
+ * Checks whether the given object and its given are modifiable
+ * @param obj - The command to modify
+ * @param key - The property of the command to modify
+ * @returns True if the property of the command can be modified.
+ */
+export function isCmdModifiable(obj: Command, key: string): boolean {
     const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
@@ -50,48 +57,53 @@ export function isCmdModifiable(obj: CommandBase, key: string): boolean {
     return false;
 }
 
-export function modifyCmdAttributes<T>(obj: T, attributes: Partial<T>): void {
-    if (!(obj instanceof CommandBase) || !obj.isDone()) {
+/**
+ * Modifies parameters of the given command
+ * @param obj - The command to modify
+ * @param attributes - The set of properties of the command to modify
+ */
+export function modifyCmdAttributes<T extends Command>(obj: T, attributes: Partial<T>): void {
+    if (!obj.isDone()) {
         console.log("Only already executed and done Interacto commands can be modified");
         return;
     }
 
-    Object.keys(attributes).forEach(key => {
+    for (const key of Object.keys(attributes)) {
         if (isCmdModifiable(obj, key)) {
-            const k = key as keyof T;
-            const value = attributes[k];
-            if (value && typeof value === typeof obj[k]) {
-                obj[k] = value as (T & CommandBase)[keyof T];
+            const tkey = key as keyof T;
+            const value = attributes[tkey];
+            if (typeof value === typeof obj[tkey]) {
+                obj[tkey] = value as (T & Command)[keyof T];
             } else {
                 console.error("Incorrect type");
             }
         } else {
             console.error("Incorrect property");
         }
-    });
+    }
 }
 
 /**
- * Returns the set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
- * @param obj The object to analyze.
+ * @param obj - The object to analyze.
+ * @returns The set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
  */
-export function getModifiableCmdAttributes<T>(obj: T & Object): Partial<T> {
+export function getModifiableCmdAttributes<T>(obj: T & object): Partial<T> {
     const modifiableAttributes: Partial<T> = {};
     const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
-        modifiables.forEach((key: unknown) => {
-            const k = key as keyof T;
+        for (const key of modifiables) {
+            const tkey = key as keyof T;
 
-            if (typeof k === "string" && k in obj) {
-                const type = typeof obj[k];
+            if (typeof tkey === "string" && tkey in obj) {
+                const type = typeof obj[tkey];
                 if (type === "string" || type === "number" || type === "boolean") {
-                    modifiableAttributes[k] = obj[k];
+                    modifiableAttributes[tkey] = obj[tkey];
                 } else {
                     console.error(type, "Cannot modify a property that is not a string, number, or boolean");
                 }
             }
-        });
+        }
     }
     return modifiableAttributes;
 }

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -29,7 +29,8 @@ interface ModifiableMetadata {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Modifiable(target: unknown, propertyName: string): void {
     if (!isUndoableType(target)) {
-        console.log("The @Modifiable decorator currently operates on Interacto undoable commands only");
+        // eslint-disable-next-line no-console
+        console.error("The @Modifiable decorator currently operates on Interacto undoable commands only");
         return;
     }
 
@@ -64,7 +65,8 @@ export function isCmdModifiable(obj: Command, key: string): boolean {
  */
 export function modifyCmdAttributes<T extends Command>(obj: T, attributes: Partial<T>): void {
     if (!obj.isDone()) {
-        console.log("Only already executed and done Interacto commands can be modified");
+        // eslint-disable-next-line no-console
+        console.error("Only already executed and done Interacto commands can be modified");
         return;
     }
 
@@ -75,10 +77,12 @@ export function modifyCmdAttributes<T extends Command>(obj: T, attributes: Parti
             if (typeof value === typeof obj[tkey]) {
                 obj[tkey] = value as (T & Command)[keyof T];
             } else {
-                console.error("Incorrect type");
+                // eslint-disable-next-line no-console
+                console.error("Trying to affect a value of an incorrect type to a parameter of a command");
             }
         } else {
-            console.error("Incorrect property");
+            // eslint-disable-next-line no-console
+            console.error("Trying to affect a value of an incorrect parameter of a command");
         }
     }
 }
@@ -100,6 +104,7 @@ export function getModifiableCmdAttributes<T>(obj: T & object): Partial<T> {
                 if (type === "string" || type === "number" || type === "boolean") {
                     modifiableAttributes[tkey] = obj[tkey];
                 } else {
+                    // eslint-disable-next-line no-console
                     console.error(type, "Cannot modify a property that is not a string, number, or boolean");
                 }
             }

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -12,6 +12,7 @@
  * along with Interacto.  If not, see <https://www.gnu.org/licenses/>.
  */
 import {isUndoableType} from "../undo/Undoable";
+import {CommandBase} from "../../impl/command/CommandBase";
 
 
 const INTERACTO_MODIFIABLE: unique symbol = Symbol('interacto-cmd-modifiable');
@@ -37,7 +38,7 @@ export function Modifiable(target: unknown, propertyName: string): void {
     target.constructor[INTERACTO_MODIFIABLE] = set;
 }
 
-export function isCmdModifiable(obj: unknown, key: string): boolean {
+export function isCmdModifiable(obj: CommandBase, key: string): boolean {
     const modifiables: unknown = obj.constructor[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
@@ -47,6 +48,11 @@ export function isCmdModifiable(obj: unknown, key: string): boolean {
 }
 
 export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: unknown }): void {
+    if(!(obj instanceof CommandBase) || !obj.isDone()) {
+        console.log("Only already executed and done Interacto commands can be modified");
+        return;
+    }
+
     Object.keys(attributes).forEach(key => {
         if (isCmdModifiable(obj, key)) {
             const value: unknown = attributes[key];

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -63,7 +63,7 @@ export function isCmdModifiable(obj: Undoable, key: string): boolean {
  * Modifies attributes of the given undoable command based on a given source partial object.
  * @param obj - The command to modify
  * @param attributes - The set of properties of the command to modify
- * @return True if the undoable command has been modified.
+ * @returns True if the undoable command has been modified.
  * False otherwise, for example, if no attribute has been modified (e.g., no corresponding attribute or
  * all the source and target attributes are equal).
  */
@@ -93,9 +93,8 @@ export function modifyCmdAttributes<T extends Command & Undoable>(obj: T, attrib
 
 /**
  * Retrieves the subset of attributes from an {@link Undoable} instance that are
- * considered modifiable (i.e., annotated with @Modifiable)
+ * considered modifiable (i.e., annotated with `@Modifiable`)
  * (only primitive types considered for the moment: string, number, or boolean).
- *
  * @param obj - The object from which to extract modifiable attributes.
  * @returns Partial<T> - An object (extracted from `obj`) containing only the properties that are
  * declared as modifiable.

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Interacto.
+ * Interacto is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Interacto is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Interacto.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import {isUndoableType} from "../undo/Undoable";
+
+
+const INTERACTO_MODIFIABLE: unique symbol = Symbol('interacto-cmd-modifiable');
+
+/**
+ * The Interacto decorator to mark command's properties as modifiable after being executed.
+ * Cannot check the type of the property here (requires reflect-metadata we do not want to install).
+ * @param target The targeted command.
+ * @param propertyName The name of the property the decorator targets.
+ */
+export function Modifiable(target: unknown, propertyName: string): void {
+    if(!isUndoableType(target)) {
+        console.log("The @Modifiable decorator currently operates on Interacto undoable commands only")
+        return;
+    }
+
+    //Getting the object cache related to the modifiable symbol
+    const symbolValues: unknown = target.constructor[INTERACTO_MODIFIABLE];
+    const set = symbolValues instanceof Set ? symbolValues as Set<string> : new Set<string>();
+
+    // Adding the property in this cache
+    set.add(propertyName);
+    target.constructor[INTERACTO_MODIFIABLE] = set;
+}
+
+export function isModifiable(obj: unknown, key: string): boolean {
+    const modifiables: unknown = obj.constructor[INTERACTO_MODIFIABLE];
+
+    if (modifiables instanceof Set) {
+        return modifiables.has(key);
+    }
+    return false;
+}
+
+export function modifyAttributes(obj: unknown, attributes: { [key: string]: unknown }): void {
+    Object.keys(attributes).forEach(key => {
+        if (isModifiable(obj, key)) {
+            const value: unknown = attributes[key];
+            const type = typeof obj[key];
+            const typeValue = typeof value;
+            if (typeValue === type && typeValue) {
+                obj[key] = value;
+            } else {
+                console.error("Incorrect type");
+            }
+        } else {
+            console.error("Incorrect property");
+        }
+    });
+}
+
+/**
+ * Returns the set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
+ * @param obj The object to analyze.
+ */
+export function getModifiableAttributes(obj: unknown): Map<string, unknown> {
+    const modifiableAttributes = new Map<string, unknown>();
+    const modifiables: unknown = obj.constructor[INTERACTO_MODIFIABLE];
+
+    if (modifiables instanceof Set && obj instanceof Object) {
+        modifiables.forEach((key: unknown) => {
+            if (typeof key === "string" && key in obj) {
+                const type = typeof obj[key];
+                if (type === "string" || type === "number" || type === "boolean") {
+                    modifiableAttributes.set(key, obj[key]);
+                } else {
+                    console.error(type, "Cannot modify a property that is not a string, number, or boolean");
+                }
+            }
+        });
+    }
+    return modifiableAttributes;
+}

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -16,6 +16,10 @@ import {CommandBase} from "../../impl/command/CommandBase";
 
 const INTERACTO_MODIFIABLE: unique symbol = Symbol('interacto-cmd-modifiable');
 
+interface ModifiableMetadata {
+    [INTERACTO_MODIFIABLE]?: Set<string>;
+}
+
 /**
  * The Interacto decorator to mark command's properties as modifiable after being executed.
  * Cannot check the type of the property here (requires reflect-metadata we do not want to install).
@@ -29,16 +33,16 @@ export function Modifiable(target: unknown, propertyName: string): void {
     }
 
     //Getting the object cache related to the modifiable symbol
-    const symbolValues: unknown = (target.constructor as any)[INTERACTO_MODIFIABLE];
+    const symbolValues: unknown = (target.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
     const set = symbolValues instanceof Set ? symbolValues as Set<string> : new Set<string>();
 
     // Adding the property in this cache
     set.add(propertyName);
-    (target.constructor as any)[INTERACTO_MODIFIABLE] = set;
+    (target.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE] = set;
 }
 
 export function isCmdModifiable(obj: CommandBase, key: string): boolean {
-    const modifiables: unknown = (obj.constructor as any)[INTERACTO_MODIFIABLE];
+    const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
         return modifiables.has(key);
@@ -46,7 +50,7 @@ export function isCmdModifiable(obj: CommandBase, key: string): boolean {
     return false;
 }
 
-export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: unknown }): void {
+export function modifyCmdAttributes<T>(obj: T, attributes: Partial<T>): void {
     if (!(obj instanceof CommandBase) || !obj.isDone()) {
         console.log("Only already executed and done Interacto commands can be modified");
         return;
@@ -54,11 +58,10 @@ export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: u
 
     Object.keys(attributes).forEach(key => {
         if (isCmdModifiable(obj, key)) {
-            const value: unknown = attributes[key];
-            const type = typeof (obj as any)[key];
-            const typeValue = typeof value;
-            if (typeValue === type && typeValue) {
-                (obj as any)[key] = value;
+            const k = key as keyof T;
+            const value = attributes[k];
+            if (value && typeof value === typeof obj[k]) {
+                obj[k] = value as (T & CommandBase)[keyof T];
             } else {
                 console.error("Incorrect type");
             }
@@ -72,16 +75,18 @@ export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: u
  * Returns the set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
  * @param obj The object to analyze.
  */
-export function getModifiableCmdAttributes(obj: Object): Map<string, unknown> {
-    const modifiableAttributes = new Map<string, unknown>();
-    const modifiables: unknown = (obj.constructor as any)[INTERACTO_MODIFIABLE];
+export function getModifiableCmdAttributes<T>(obj: T & Object): Partial<T> {
+    const modifiableAttributes: Partial<T> = {};
+    const modifiables: unknown = (obj.constructor as ModifiableMetadata)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
         modifiables.forEach((key: unknown) => {
-            if (typeof key === "string" && key in obj) {
-                const type = typeof (obj as any)[key];
+            const k = key as keyof T;
+
+            if (typeof k === "string" && k in obj) {
+                const type = typeof obj[k];
                 if (type === "string" || type === "number" || type === "boolean") {
-                    modifiableAttributes.set(key, (obj as any)[key]);
+                    modifiableAttributes[k] = obj[k];
                 } else {
                     console.error(type, "Cannot modify a property that is not a string, number, or boolean");
                 }

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -60,23 +60,25 @@ export function isCmdModifiable(obj: Undoable, key: string): boolean {
 }
 
 /**
- * Modifies parameters of the given command
+ * Modifies attributes of the given undoable command based on a given source partial object.
  * @param obj - The command to modify
  * @param attributes - The set of properties of the command to modify
+ * @return True if the undoable command has been modified.
+ * False otherwise, for example, if no attribute has been modified (e.g., no corresponding attribute or
+ * all the source and target attributes are equal).
  */
-export function modifyCmdAttributes<T extends Command & Undoable>(obj: T, attributes: Partial<T>): void {
-    if (!obj.isDone()) {
-        // eslint-disable-next-line no-console
-        console.error("Only already executed and done Interacto commands can be modified");
-        return;
-    }
+export function modifyCmdAttributes<T extends Command & Undoable>(obj: T, attributes: Partial<T>): boolean {
+    let hasChanged = false;
 
     for (const key of Object.keys(attributes)) {
         if (isCmdModifiable(obj, key)) {
             const tkey = key as keyof T;
             const value = attributes[tkey];
             if (typeof value === typeof obj[tkey]) {
-                obj[tkey] = value as T[keyof T];
+                if (value !== obj[tkey]) {
+                    obj[tkey] = value as T[keyof T];
+                    hasChanged = true;
+                }
             } else {
                 // eslint-disable-next-line no-console
                 console.error("Trying to affect a value of an incorrect type to a parameter of a command");
@@ -86,11 +88,17 @@ export function modifyCmdAttributes<T extends Command & Undoable>(obj: T, attrib
             console.error("Trying to affect a value of an incorrect parameter of a command");
         }
     }
+    return hasChanged;
 }
 
 /**
- * @param obj - The object to analyze.
- * @returns The set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
+ * Retrieves the subset of attributes from an {@link Undoable} instance that are
+ * considered modifiable (i.e., annotated with @Modifiable)
+ * (only primitive types considered for the moment: string, number, or boolean).
+ *
+ * @param obj - The object from which to extract modifiable attributes.
+ * @returns Partial<T> - An object (extracted from `obj`) containing only the properties that are
+ * declared as modifiable.
  */
 export function getModifiableCmdAttributes<T extends Undoable>(obj: T): Partial<T> {
     const modifiableAttributes: Partial<T> = {};

--- a/src/api/command/ModifiableCommand.ts
+++ b/src/api/command/ModifiableCommand.ts
@@ -14,7 +14,6 @@
 import {isUndoableType} from "../undo/Undoable";
 import {CommandBase} from "../../impl/command/CommandBase";
 
-
 const INTERACTO_MODIFIABLE: unique symbol = Symbol('interacto-cmd-modifiable');
 
 /**
@@ -24,22 +23,22 @@ const INTERACTO_MODIFIABLE: unique symbol = Symbol('interacto-cmd-modifiable');
  * @param propertyName The name of the property the decorator targets.
  */
 export function Modifiable(target: unknown, propertyName: string): void {
-    if(!isUndoableType(target)) {
+    if (!isUndoableType(target)) {
         console.log("The @Modifiable decorator currently operates on Interacto undoable commands only")
         return;
     }
 
     //Getting the object cache related to the modifiable symbol
-    const symbolValues: unknown = target.constructor[INTERACTO_MODIFIABLE];
+    const symbolValues: unknown = (target.constructor as any)[INTERACTO_MODIFIABLE];
     const set = symbolValues instanceof Set ? symbolValues as Set<string> : new Set<string>();
 
     // Adding the property in this cache
     set.add(propertyName);
-    target.constructor[INTERACTO_MODIFIABLE] = set;
+    (target.constructor as any)[INTERACTO_MODIFIABLE] = set;
 }
 
 export function isCmdModifiable(obj: CommandBase, key: string): boolean {
-    const modifiables: unknown = obj.constructor[INTERACTO_MODIFIABLE];
+    const modifiables: unknown = (obj.constructor as any)[INTERACTO_MODIFIABLE];
 
     if (modifiables instanceof Set) {
         return modifiables.has(key);
@@ -48,7 +47,7 @@ export function isCmdModifiable(obj: CommandBase, key: string): boolean {
 }
 
 export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: unknown }): void {
-    if(!(obj instanceof CommandBase) || !obj.isDone()) {
+    if (!(obj instanceof CommandBase) || !obj.isDone()) {
         console.log("Only already executed and done Interacto commands can be modified");
         return;
     }
@@ -56,10 +55,10 @@ export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: u
     Object.keys(attributes).forEach(key => {
         if (isCmdModifiable(obj, key)) {
             const value: unknown = attributes[key];
-            const type = typeof obj[key];
+            const type = typeof (obj as any)[key];
             const typeValue = typeof value;
             if (typeValue === type && typeValue) {
-                obj[key] = value;
+                (obj as any)[key] = value;
             } else {
                 console.error("Incorrect type");
             }
@@ -73,16 +72,16 @@ export function modifyCmdAttributes(obj: unknown, attributes: { [key: string]: u
  * Returns the set of modifiable (i.e., properties with the Interacto decorator Modifiable) properties of the given object.
  * @param obj The object to analyze.
  */
-export function getModifiableCmdAttributes(obj: unknown): Map<string, unknown> {
+export function getModifiableCmdAttributes(obj: Object): Map<string, unknown> {
     const modifiableAttributes = new Map<string, unknown>();
-    const modifiables: unknown = obj.constructor[INTERACTO_MODIFIABLE];
+    const modifiables: unknown = (obj.constructor as any)[INTERACTO_MODIFIABLE];
 
-    if (modifiables instanceof Set && obj instanceof Object) {
+    if (modifiables instanceof Set) {
         modifiables.forEach((key: unknown) => {
             if (typeof key === "string" && key in obj) {
-                const type = typeof obj[key];
+                const type = typeof (obj as any)[key];
                 if (type === "string" || type === "number" || type === "boolean") {
-                    modifiableAttributes.set(key, obj[key]);
+                    modifiableAttributes.set(key, (obj as any)[key]);
                 } else {
                     console.error(type, "Cannot modify a property that is not a string, number, or boolean");
                 }

--- a/src/api/undo/TreeUndoHistory.ts
+++ b/src/api/undo/TreeUndoHistory.ts
@@ -154,6 +154,27 @@ export abstract class TreeUndoHistory implements UndoHistoryBase {
     public abstract delete(id: number): void;
 
     /**
+     * Retrieves the modifiable attributes of the undoable node identified by the given id.
+     * See the method `getModifiableCmdAttributes` in the class `ModifiableCommand`.
+     * @param {number} id - The id of the undoable to retrieve.
+     * @return {object} An object containing the modifiable attributes of the targeted undoable node with their current values.
+     * The method returns an empty structured if no node matches the given id.
+     */
+    public abstract getModifiableAttributesOf(id: number): object;
+
+    /**
+     * Applies modified attributes to the command identified by the given `id` within the undoable nodes.
+     * Technically, the method clones the targeted undoable node, applies the modifications from `data`, re-executes the command,
+     * and then stores the novel cloned undoable node in the history.
+     *
+     * @param {number} id - The identifier of the undoable node to modify (to clone and then patch).
+     * The method does nothing if the id is not valid.
+     * @param {object} data - The attribute changes to apply to the command. JSON format.
+     * The elements of the JSON object must match with the class attributes (tagged with @Modifiable) of the undoable object.
+     */
+    public abstract applyModifiedAttributesOn(id: number, data: object): void;
+
+    /**
      * Computes the position (in the large) of each node.
      * Useful for layouting.
      */

--- a/src/api/undo/TreeUndoHistory.ts
+++ b/src/api/undo/TreeUndoHistory.ts
@@ -156,8 +156,8 @@ export abstract class TreeUndoHistory implements UndoHistoryBase {
     /**
      * Retrieves the modifiable attributes of the undoable node identified by the given id.
      * See the method `getModifiableCmdAttributes` in the class `ModifiableCommand`.
-     * @param {number} id - The id of the undoable to retrieve.
-     * @return {object} An object containing the modifiable attributes of the targeted undoable node with their current values.
+     * @param id - The id of the undoable to retrieve.
+     * @returns An object containing the modifiable attributes of the targeted undoable node with their current values.
      * The method returns an empty structured if no node matches the given id.
      */
     public abstract getModifiableAttributesOf(id: number): object;
@@ -166,11 +166,10 @@ export abstract class TreeUndoHistory implements UndoHistoryBase {
      * Applies modified attributes to the command identified by the given `id` within the undoable nodes.
      * Technically, the method clones the targeted undoable node, applies the modifications from `data`, re-executes the command,
      * and then stores the novel cloned undoable node in the history.
-     *
-     * @param {number} id - The identifier of the undoable node to modify (to clone and then patch).
+     * @param id - The identifier of the undoable node to modify (to clone and then patch).
      * The method does nothing if the id is not valid.
-     * @param {object} data - The attribute changes to apply to the command. JSON format.
-     * The elements of the JSON object must match with the class attributes (tagged with @Modifiable) of the undoable object.
+     * @param data - The attribute changes to apply to the command. JSON format.
+     * The elements of the JSON object must match with the class attributes (tagged with `@Modifiable`) of the undoable object.
      */
     public abstract applyModifiedAttributesOn(id: number, data: object): void;
 

--- a/src/impl/undo/TreeUndoHistoryImpl.ts
+++ b/src/impl/undo/TreeUndoHistoryImpl.ts
@@ -18,8 +18,13 @@ import {remove} from "../util/ArrayUtil";
 import {Subject} from "rxjs";
 import type {UndoableTreeNode, UndoableTreeNodeDTO, TreeUndoHistoryDTO} from "../../api/undo/TreeUndoHistory";
 import type {Undoable, UndoableSnapshot} from "../../api/undo/Undoable";
-import type {Observable} from "rxjs";
 import type {UndoableCommand} from "../command/UndoableCommand";
+import type {Observable} from "rxjs";
+
+/**
+ * A temporary type for casting an undoable object constructor to then call it.
+ */
+type UndoableCtor = new () => UndoableCommand;
 
 /**
  * Implementation of UndoableTreeNode
@@ -154,7 +159,6 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
         this.sizePublisher = new Subject();
     }
 
-
     public add(undoable: Undoable): void {
         let equalCmd: UndoableTreeNode | undefined;
 
@@ -234,7 +238,6 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
         }
     }
 
-
     public getModifiableAttributesOf(id: number): object {
         const node = this.undoableNodes.at(id);
         if (node === undefined) {
@@ -243,9 +246,9 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
         return getModifiableCmdAttributes(node.undoable);
     }
 
-
     public applyModifiedAttributesOn(id: number, data: object): void {
-        const node = this.undoableNodes[id]; // not `at(i)` since at considers -1 as last one
+        // not `at(i)` since at considers -1 as last one
+        const node = this.undoableNodes[id];
         const parent = node?.parent;
         if (node === undefined || parent === undefined) {
             return;
@@ -256,7 +259,7 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
         // Apply the change to the targeted undoable object (the tree root of the cloned subtree)
         const hasBeenChanged = modifyCmdAttributes(cloneTree.undoable as UndoableCommand, data);
         // If the modification process does not modify the input undoable object, the process stops here
-        if(hasBeenChanged) {
+        if (hasBeenChanged) {
             // Moving to the parent of the modified item
             this.goTo(parent.id);
             // Executing the cloned undoable object
@@ -273,7 +276,7 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
     }
 
     private addClonedSubtree(currentNode: UndoableTreeNode): void {
-        for(const child of currentNode.children) {
+        for (const child of currentNode.children) {
             child.undoable.redo();
             this.add(child.undoable);
             this.undo();
@@ -283,7 +286,8 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
 
     private cloneSubtree(node: UndoableTreeNode, parent?: UndoableTreeNode): UndoableTreeNode {
         // Cloning the current undoable
-        let clone = new (node.undoable.constructor as any) as UndoableCommand;
+        // eslint-disable-next-line @stylistic/new-parens
+        let clone = new (node.undoable.constructor as UndoableCtor);
         clone = Object.assign(clone, node.undoable);
         // Creating a fake node to store the cloned branch
         const clonedNode = new UndoableTreeNodeImpl(clone, -1, parent);
@@ -294,8 +298,6 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
 
         return clonedNode;
     }
-
-
 
     public goTo(id: number): void {
         if (this.currentNode.id === id || this.undoableNodes.length === 0 || id >= this.undoableNodes.length || id < -1) {

--- a/src/impl/undo/TreeUndoHistoryImpl.ts
+++ b/src/impl/undo/TreeUndoHistoryImpl.ts
@@ -12,12 +12,14 @@
  * along with Interacto.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {getModifiableCmdAttributes, modifyCmdAttributes} from "../../api/command/ModifiableCommand";
 import {TreeUndoHistory} from "../../api/undo/TreeUndoHistory";
 import {remove} from "../util/ArrayUtil";
 import {Subject} from "rxjs";
 import type {UndoableTreeNode, UndoableTreeNodeDTO, TreeUndoHistoryDTO} from "../../api/undo/TreeUndoHistory";
 import type {Undoable, UndoableSnapshot} from "../../api/undo/Undoable";
 import type {Observable} from "rxjs";
+import type {UndoableCommand} from "../command/UndoableCommand";
 
 /**
  * Implementation of UndoableTreeNode
@@ -152,6 +154,7 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
         this.sizePublisher = new Subject();
     }
 
+
     public add(undoable: Undoable): void {
         let equalCmd: UndoableTreeNode | undefined;
 
@@ -230,6 +233,69 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
             this._currentNode = this.root;
         }
     }
+
+
+    public getModifiableAttributesOf(id: number): object {
+        const node = this.undoableNodes.at(id);
+        if (node === undefined) {
+            return {};
+        }
+        return getModifiableCmdAttributes(node.undoable);
+    }
+
+
+    public applyModifiedAttributesOn(id: number, data: object): void {
+        const node = this.undoableNodes[id]; // not `at(i)` since at considers -1 as last one
+        const parent = node?.parent;
+        if (node === undefined || parent === undefined) {
+            return;
+        }
+
+        // cloning the branch
+        const cloneTree = this.cloneSubtree(node);
+        // Apply the change to the targeted undoable object (the tree root of the cloned subtree)
+        const hasBeenChanged = modifyCmdAttributes(cloneTree.undoable as UndoableCommand, data);
+        // If the modification process does not modify the input undoable object, the process stops here
+        if(hasBeenChanged) {
+            // Moving to the parent of the modified item
+            this.goTo(parent.id);
+            // Executing the cloned undoable object
+            cloneTree.undoable.redo();
+            // Adding the novel commands to the history
+            this.add(cloneTree.undoable);
+            const currentId = this.currentNode.id;
+            // Adding and executing the cloned branch
+            // Execution is required to trigger the creation of this new history branch
+            this.addClonedSubtree(cloneTree);
+            // Going back to the original position
+            this.goTo(currentId);
+        }
+    }
+
+    private addClonedSubtree(currentNode: UndoableTreeNode): void {
+        for(const child of currentNode.children) {
+            child.undoable.redo();
+            this.add(child.undoable);
+            this.undo();
+            this.addClonedSubtree(child);
+        }
+    }
+
+    private cloneSubtree(node: UndoableTreeNode, parent?: UndoableTreeNode): UndoableTreeNode {
+        // Cloning the current undoable
+        let clone = new (node.undoable.constructor as any) as UndoableCommand;
+        clone = Object.assign(clone, node.undoable);
+        // Creating a fake node to store the cloned branch
+        const clonedNode = new UndoableTreeNodeImpl(clone, -1, parent);
+        // Cloning all the children
+        for (const child of Array.from(node.children)) {
+            clonedNode.children.push(this.cloneSubtree(child, clonedNode));
+        }
+
+        return clonedNode;
+    }
+
+
 
     public goTo(id: number): void {
         if (this.currentNode.id === id || this.undoableNodes.length === 0 || id >= this.undoableNodes.length || id < -1) {

--- a/src/impl/undo/TreeUndoHistoryImpl.ts
+++ b/src/impl/undo/TreeUndoHistoryImpl.ts
@@ -260,18 +260,25 @@ export class TreeUndoHistoryImpl extends TreeUndoHistory {
         const hasBeenChanged = modifyCmdAttributes(cloneTree.undoable as UndoableCommand, data);
         // If the modification process does not modify the input undoable object, the process stops here
         if (hasBeenChanged) {
-            // Moving to the parent of the modified item
-            this.goTo(parent.id);
-            // Executing the cloned undoable object
-            cloneTree.undoable.redo();
-            // Adding the novel commands to the history
-            this.add(cloneTree.undoable);
-            const currentId = this.currentNode.id;
-            // Adding and executing the cloned branch
-            // Execution is required to trigger the creation of this new history branch
-            this.addClonedSubtree(cloneTree);
-            // Going back to the original position
-            this.goTo(currentId);
+            // If we have to check equal undoables, then checking the siblings
+            const isNew = !this.considersEqualCmds ||
+              !parent.children.some(elt => cloneTree.undoable.equals(elt.undoable));
+
+            if (isNew) {
+                // Moving to the parent of the modified item
+                this.goTo(parent.id);
+                // Executing the cloned undoable object
+                cloneTree.undoable.redo();
+                // Adding the novel commands to the history
+                this.add(cloneTree.undoable);
+                const currentId = this.currentNode.id;
+                // Adding and executing the cloned branch
+                // Execution is required to trigger the creation of this new history branch
+                this.addClonedSubtree(cloneTree);
+                // Going back to the original position
+                this.goTo(currentId);
+            }
+
         }
     }
 

--- a/src/interacto.ts
+++ b/src/interacto.ts
@@ -29,6 +29,7 @@ export * from "./api/binding/BindingsObserver";
 export * from "./api/binding/VisitorBinding";
 export * from "./api/checker/Checker";
 export * from "./api/command/Command";
+export * from "./api/command/ModifiableCommand";
 export * from "./api/fsm/ConcurrentFSM";
 export * from "./api/fsm/EventType";
 export * from "./api/fsm/FSM";

--- a/test/command/StubCmd.ts
+++ b/test/command/StubCmd.ts
@@ -12,8 +12,18 @@
  * along with Interacto.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {CommandBase} from "../../src/interacto";
+import {CommandBase, UndoableCommand} from "../../src/interacto";
 import type {Undoable} from "../../src/interacto";
+
+export class ExampleUndoableCmd extends UndoableCommand {
+    protected execution(): Promise<void> | void {
+        return undefined;
+    }
+
+    public redo(): void {}
+
+    public undo(): void {}
+}
 
 export class StubCmd extends CommandBase {
     public candoValue: boolean;

--- a/test/command/StubCmd.ts
+++ b/test/command/StubCmd.ts
@@ -12,8 +12,7 @@
  * along with Interacto.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {CommandBase, Modifiable, UndoableCommand} from "../../src/interacto";
-import type {Undoable} from "../../src/interacto";
+import {CommandBase, Modifiable, UndoableCommand, type Undoable} from "../../src/interacto";
 
 export class ExampleUndoableCmd extends UndoableCommand {
     protected execution(): Promise<void> | void {
@@ -105,5 +104,10 @@ export class CmdModifiableDouble extends ExampleUndoableCmd {
 
     public override redo(): void {
         this.re++;
+    }
+
+    public override equals(undoable: unknown): boolean {
+        return undoable instanceof CmdModifiableDouble && undoable.a === this.a && undoable.b === this.b &&
+          undoable.c === this.c && undoable.c === this.c;
     }
 }

--- a/test/command/StubCmd.ts
+++ b/test/command/StubCmd.ts
@@ -12,7 +12,7 @@
  * along with Interacto.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {CommandBase, UndoableCommand} from "../../src/interacto";
+import {CommandBase, Modifiable, UndoableCommand} from "../../src/interacto";
 import type {Undoable} from "../../src/interacto";
 
 export class ExampleUndoableCmd extends UndoableCommand {
@@ -65,5 +65,45 @@ export class StubUndoableCmd extends StubCmd implements Undoable {
 
     public equals(_undoable: Undoable): boolean {
         return false;
+    }
+}
+
+export class CmdModifiableDouble2 extends StubCmd {
+    @Modifiable
+    public a = 0;
+}
+
+export class CmdModifiableDouble3 extends ExampleUndoableCmd {
+    @Modifiable
+    public a = {};
+
+    @Modifiable
+    public b: Array<string> = [];
+
+    @Modifiable
+    public c: number | undefined = undefined;
+}
+
+export class CmdModifiableDouble extends ExampleUndoableCmd {
+    @Modifiable
+    public a: number;
+
+    @Modifiable
+    public b: boolean;
+
+    public c: string;
+
+    public re: number;
+
+    public constructor() {
+        super();
+        this.a = 0;
+        this.b = false;
+        this.c = "foo";
+        this.re = 0;
+    }
+
+    public override redo(): void {
+        this.re++;
     }
 }

--- a/test/command/UndoableCommand.test.ts
+++ b/test/command/UndoableCommand.test.ts
@@ -18,7 +18,7 @@ import {beforeEach, describe, expect, test} from "@jest/globals";
 
 let cmd: UndoableCommand;
 
-class ExampleUndoableCmd extends UndoableCommand {
+export class ExampleUndoableCmd extends UndoableCommand {
     protected execution(): Promise<void> | void {
         return undefined;
     }

--- a/test/command/UndoableCommand.test.ts
+++ b/test/command/UndoableCommand.test.ts
@@ -13,20 +13,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {UndoableCommand} from "../../src/interacto";
 import {beforeEach, describe, expect, test} from "@jest/globals";
+import {ExampleUndoableCmd} from "./StubCmd";
+import type {UndoableCommand} from "../../src/impl/command/UndoableCommand";
 
 let cmd: UndoableCommand;
-
-export class ExampleUndoableCmd extends UndoableCommand {
-    protected execution(): Promise<void> | void {
-        return undefined;
-    }
-
-    public redo(): void {}
-
-    public undo(): void {}
-}
 
 describe("using an undoable command", () => {
     beforeEach(() => {

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -47,6 +47,7 @@ describe("using a modifiable decorator on commands", () => {
 
         beforeEach(() => {
             cmd = new CmdModifiableDouble();
+            cmd.done();
         });
 
         test("can modify one property with @Modifiable", () => {

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,0 +1,158 @@
+import {getModifiableAttributes, Modifiable, modifyAttributes} from "../../../src/api/command/ModifiableCommand";
+import {beforeEach, describe, test} from "@jest/globals";
+import {ExampleUndoableCmd} from "../UndoableCommand.test";
+import {StubCmd} from "../StubCmd";
+
+class CmdModifiableDouble2 extends StubCmd {
+    @Modifiable
+    public a: number = 0;
+}
+
+class Foo {
+    @Modifiable
+    public a: number = 0;
+}
+
+class CmdModifiableDouble3 extends ExampleUndoableCmd {
+    @Modifiable
+    public a: Object = {};
+
+    @Modifiable
+    public b: Array<string> = [];
+
+    @Modifiable
+    public c: number | undefined = undefined;
+}
+
+class CmdModifiableDouble extends ExampleUndoableCmd {
+    @Modifiable
+    public a: number;
+
+    @Modifiable
+    public b: boolean;
+
+    public c: string;
+
+    public constructor() {
+        super();
+        this.a = 0;
+        this.b = false
+        this.c = "foo";
+    }
+}
+
+describe("using a modifiable decorator on commands", () => {
+    describe("and an undoable command", () => {
+        let cmd: CmdModifiableDouble;
+
+        beforeEach(() => {
+            cmd = new CmdModifiableDouble();
+        });
+
+        test("can modify one property with @Modifiable", () => {
+            modifyAttributes(cmd, {
+                a: 21
+            });
+
+            expect(cmd.a).toBe(21);
+            expect(cmd.b).toBeFalsy();
+            expect(cmd.c).toBe("foo");
+        });
+
+        test("can modify one property several times with @Modifiable", () => {
+            modifyAttributes(cmd, {
+                a: 21
+            });
+            modifyAttributes(cmd, {
+                a: 22
+            });
+
+            expect(cmd.a).toBe(22);
+        });
+
+        test("can modify two properties with @Modifiable", () => {
+            modifyAttributes(cmd, {
+                b: true,
+                a: 42
+            });
+
+            expect(cmd.a).toBe(42);
+            expect(cmd.b).toBeTruthy();
+            expect(cmd.c).toBe("foo");
+        });
+
+        test("cannot modify one property without @Modifiable", () => {
+            modifyAttributes(cmd, {
+                c: "yolo",
+                a: 1
+            });
+
+            expect(cmd.a).toBe(1);
+            expect(cmd.b).toBeFalsy();
+            expect(cmd.c).toBe("foo");
+        });
+
+        test("cannot modify one non-existing property", () => {
+            modifyAttributes(cmd, {
+                c2: "yolo",
+                a: -1
+            });
+
+            expect(cmd.a).toBe(-1);
+            expect(cmd.b).toBeFalsy();
+        });
+
+        test("cannot modify one property with a incorrectly typed value", () => {
+            modifyAttributes(cmd, {
+                a: "100",
+                b: "200"
+            });
+
+            expect(cmd.a).toBe(0);
+            expect(cmd.b).toBeFalsy();
+        });
+
+        test("get modifiable properties", () => {
+            const attributes = getModifiableAttributes(cmd);
+            expect(attributes).toEqual(new Map<string, unknown>([["a", 0], ["b", false]]));
+        });
+
+        describe("and an undoable command with incorrect usages of Modifiable", () => {
+            let cmd: CmdModifiableDouble3;
+
+            beforeEach(() => {
+                cmd = new CmdModifiableDouble3();
+            });
+
+            test("get modifiable properties does not include the ones badly typed", () => {
+                expect(getModifiableAttributes(cmd)).toEqual(new Map<string, unknown>());
+            });
+        });
+    });
+
+    describe("and an non-undoable command", () => {
+        test("with a standard command", () => {
+            const cmd = new CmdModifiableDouble2();
+            modifyAttributes(cmd, {
+                a: 21
+            });
+
+            expect(cmd.a).toBe(0);
+        });
+
+        test("get modifiable properties", () => {
+            const cmd = new CmdModifiableDouble2();
+            const attributes = getModifiableAttributes(cmd);
+            expect(attributes).toEqual(new Map<string, unknown>());
+        });
+
+        test("with an object", () => {
+            const foo = new Foo();
+            modifyAttributes(foo, {
+                a: 21
+            });
+
+            expect(foo.a).toBe(0);
+        });
+    });
+});

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,4 +1,4 @@
-import {getModifiableAttributes, Modifiable, modifyAttributes} from "../../../src/api/command/ModifiableCommand";
+import {getModifiableCmdAttributes, Modifiable, modifyCmdAttributes} from "../../../src/api/command/ModifiableCommand";
 import {beforeEach, describe, test} from "@jest/globals";
 import {ExampleUndoableCmd} from "../UndoableCommand.test";
 import {StubCmd} from "../StubCmd";
@@ -50,7 +50,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("can modify one property with @Modifiable", () => {
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 a: 21
             });
 
@@ -60,10 +60,10 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("can modify one property several times with @Modifiable", () => {
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 a: 21
             });
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 a: 22
             });
 
@@ -71,7 +71,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("can modify two properties with @Modifiable", () => {
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 b: true,
                 a: 42
             });
@@ -82,7 +82,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("cannot modify one property without @Modifiable", () => {
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 c: "yolo",
                 a: 1
             });
@@ -93,7 +93,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("cannot modify one non-existing property", () => {
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 c2: "yolo",
                 a: -1
             });
@@ -103,7 +103,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("cannot modify one property with a incorrectly typed value", () => {
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 a: "100",
                 b: "200"
             });
@@ -113,7 +113,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("get modifiable properties", () => {
-            const attributes = getModifiableAttributes(cmd);
+            const attributes = getModifiableCmdAttributes(cmd);
             expect(attributes).toEqual(new Map<string, unknown>([["a", 0], ["b", false]]));
         });
 
@@ -125,7 +125,7 @@ describe("using a modifiable decorator on commands", () => {
             });
 
             test("get modifiable properties does not include the ones badly typed", () => {
-                expect(getModifiableAttributes(cmd)).toEqual(new Map<string, unknown>());
+                expect(getModifiableCmdAttributes(cmd)).toEqual(new Map<string, unknown>());
             });
         });
     });
@@ -133,7 +133,7 @@ describe("using a modifiable decorator on commands", () => {
     describe("and an non-undoable command", () => {
         test("with a standard command", () => {
             const cmd = new CmdModifiableDouble2();
-            modifyAttributes(cmd, {
+            modifyCmdAttributes(cmd, {
                 a: 21
             });
 
@@ -142,13 +142,13 @@ describe("using a modifiable decorator on commands", () => {
 
         test("get modifiable properties", () => {
             const cmd = new CmdModifiableDouble2();
-            const attributes = getModifiableAttributes(cmd);
+            const attributes = getModifiableCmdAttributes(cmd);
             expect(attributes).toEqual(new Map<string, unknown>());
         });
 
         test("with an object", () => {
             const foo = new Foo();
-            modifyAttributes(foo, {
+            modifyCmdAttributes(foo, {
                 a: 21
             });
 

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -94,7 +94,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("cannot modify one non-existing property", () => {
-            modifyCmdAttributes(cmd, {
+            modifyCmdAttributes(cmd as any, {
                 c2: "yolo",
                 a: -1
             });
@@ -104,7 +104,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("cannot modify one property with a incorrectly typed value", () => {
-            modifyCmdAttributes(cmd, {
+            modifyCmdAttributes(cmd as any, {
                 a: "100",
                 b: "200"
             });
@@ -115,7 +115,7 @@ describe("using a modifiable decorator on commands", () => {
 
         test("get modifiable properties", () => {
             const attributes = getModifiableCmdAttributes(cmd);
-            expect(attributes).toEqual(new Map<string, unknown>([["a", 0], ["b", false]]));
+            expect(attributes).toEqual({"a": 0, "b": false});
         });
 
         describe("and an undoable command with incorrect usages of Modifiable", () => {
@@ -126,7 +126,7 @@ describe("using a modifiable decorator on commands", () => {
             });
 
             test("get modifiable properties does not include the ones badly typed", () => {
-                expect(getModifiableCmdAttributes(cmd)).toEqual(new Map<string, unknown>());
+                expect(getModifiableCmdAttributes(cmd)).toEqual({});
             });
         });
     });
@@ -144,7 +144,7 @@ describe("using a modifiable decorator on commands", () => {
         test("get modifiable properties", () => {
             const cmd = new CmdModifiableDouble2();
             const attributes = getModifiableCmdAttributes(cmd);
-            expect(attributes).toEqual(new Map<string, unknown>());
+            expect(attributes).toEqual({});
         });
 
         test("with an object", () => {

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,4 +1,4 @@
-import {getModifiableCmdAttributes, Modifiable, modifyCmdAttributes} from "../../../src/api/command/ModifiableCommand";
+import {getModifiableCmdAttributes, isCmdModifiable, Modifiable, modifyCmdAttributes} from "../../../src/api/command/ModifiableCommand";
 import {beforeEach, describe, expect, test} from "@jest/globals";
 import {ExampleUndoableCmd, StubCmd} from "../StubCmd";
 
@@ -122,8 +122,14 @@ describe("using a modifiable decorator on commands", () => {
     });
 
     describe("and an non-undoable command", () => {
+        let cmd: CmdModifiableDouble2;
+
+        beforeEach(() => {
+            cmd = new CmdModifiableDouble2();
+            cmd.done();
+        });
+
         test("with a standard command", () => {
-            const cmd = new CmdModifiableDouble2();
             modifyCmdAttributes(cmd, {
                 a: 21
             });
@@ -132,9 +138,12 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("get modifiable properties", () => {
-            const cmd = new CmdModifiableDouble2();
             const attributes = getModifiableCmdAttributes(cmd);
             expect(attributes).toStrictEqual({});
+        });
+
+        test("with not a set as cache", () => {
+            expect(isCmdModifiable(cmd, "a")).toBeFalsy();
         });
     });
 });

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -56,7 +56,7 @@ describe("using a modifiable decorator on commands", () => {
             expect(cmd.c).toBe("foo");
         });
 
-        test("does nothing since same value (1 attr)", () => {
+        test("does nothing since same value (1 attribute)", () => {
             const res = modifyCmdAttributes(cmd, {
                 a: 0
             });
@@ -64,7 +64,7 @@ describe("using a modifiable decorator on commands", () => {
             expect(res).toBeFalsy();
         });
 
-        test("does nothing since same value (1 attr)", () => {
+        test("does nothing since same value (2 attributes)", () => {
             const res = modifyCmdAttributes(cmd, {
                 a: 0,
                 b: true

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,21 +1,16 @@
 import {getModifiableCmdAttributes, Modifiable, modifyCmdAttributes} from "../../../src/api/command/ModifiableCommand";
-import {beforeEach, describe, test} from "@jest/globals";
+import {beforeEach, describe, expect, test} from "@jest/globals";
 import {ExampleUndoableCmd} from "../UndoableCommand.test";
 import {StubCmd} from "../StubCmd";
 
 class CmdModifiableDouble2 extends StubCmd {
     @Modifiable
-    public a: number = 0;
-}
-
-class Foo {
-    @Modifiable
-    public a: number = 0;
+    public a = 0;
 }
 
 class CmdModifiableDouble3 extends ExampleUndoableCmd {
     @Modifiable
-    public a: Object = {};
+    public a = {};
 
     @Modifiable
     public b: Array<string> = [];
@@ -36,7 +31,7 @@ class CmdModifiableDouble extends ExampleUndoableCmd {
     public constructor() {
         super();
         this.a = 0;
-        this.b = false
+        this.b = false;
         this.c = "foo";
     }
 }
@@ -94,6 +89,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("cannot modify one non-existing property", () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             modifyCmdAttributes(cmd as any, {
                 c2: "yolo",
                 a: -1
@@ -104,6 +100,7 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("cannot modify one property with a incorrectly typed value", () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             modifyCmdAttributes(cmd as any, {
                 a: "100",
                 b: "200"
@@ -115,18 +112,12 @@ describe("using a modifiable decorator on commands", () => {
 
         test("get modifiable properties", () => {
             const attributes = getModifiableCmdAttributes(cmd);
-            expect(attributes).toEqual({"a": 0, "b": false});
+            expect(attributes).toStrictEqual({"a": 0, "b": false});
         });
 
         describe("and an undoable command with incorrect usages of Modifiable", () => {
-            let cmd: CmdModifiableDouble3;
-
-            beforeEach(() => {
-                cmd = new CmdModifiableDouble3();
-            });
-
             test("get modifiable properties does not include the ones badly typed", () => {
-                expect(getModifiableCmdAttributes(cmd)).toEqual({});
+                expect(getModifiableCmdAttributes(new CmdModifiableDouble3())).toStrictEqual({});
             });
         });
     });
@@ -144,16 +135,7 @@ describe("using a modifiable decorator on commands", () => {
         test("get modifiable properties", () => {
             const cmd = new CmdModifiableDouble2();
             const attributes = getModifiableCmdAttributes(cmd);
-            expect(attributes).toEqual({});
-        });
-
-        test("with an object", () => {
-            const foo = new Foo();
-            modifyCmdAttributes(foo, {
-                a: 21
-            });
-
-            expect(foo.a).toBe(0);
+            expect(attributes).toStrictEqual({});
         });
     });
 });

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,6 +1,7 @@
 import {getModifiableCmdAttributes, isCmdModifiable, Modifiable, modifyCmdAttributes} from "../../../src/api/command/ModifiableCommand";
 import {beforeEach, describe, expect, test} from "@jest/globals";
 import {ExampleUndoableCmd, StubCmd} from "../StubCmd";
+import type {UndoableCommand} from "../../../src/impl/command/UndoableCommand";
 
 class CmdModifiableDouble2 extends StubCmd {
     @Modifiable
@@ -143,7 +144,8 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("with a standard command", () => {
-            modifyCmdAttributes(cmd, {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            modifyCmdAttributes(cmd as any, {
                 a: 21
             });
 
@@ -151,12 +153,14 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("get modifiable properties", () => {
-            const attributes = getModifiableCmdAttributes(cmd);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const attributes = getModifiableCmdAttributes(cmd as any as UndoableCommand);
             expect(attributes).toStrictEqual({});
         });
 
         test("with not a set as cache", () => {
-            expect(isCmdModifiable(cmd, "a")).toBeFalsy();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect(isCmdModifiable(cmd as any as UndoableCommand, "a")).toBeFalsy();
         });
     });
 });

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,7 +1,6 @@
 import {getModifiableCmdAttributes, Modifiable, modifyCmdAttributes} from "../../../src/api/command/ModifiableCommand";
 import {beforeEach, describe, expect, test} from "@jest/globals";
-import {ExampleUndoableCmd} from "../UndoableCommand.test";
-import {StubCmd} from "../StubCmd";
+import {ExampleUndoableCmd, StubCmd} from "../StubCmd";
 
 class CmdModifiableDouble2 extends StubCmd {
     @Modifiable

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,40 +1,7 @@
-import {getModifiableCmdAttributes, isCmdModifiable, Modifiable, modifyCmdAttributes} from "../../../src/interacto";
+import {getModifiableCmdAttributes, isCmdModifiable, modifyCmdAttributes} from "../../../src/interacto";
 import {beforeEach, describe, expect, test} from "@jest/globals";
-import {ExampleUndoableCmd, StubCmd} from "../StubCmd";
 import type {UndoableCommand} from "../../../src/interacto";
-
-class CmdModifiableDouble2 extends StubCmd {
-    @Modifiable
-    public a = 0;
-}
-
-class CmdModifiableDouble3 extends ExampleUndoableCmd {
-    @Modifiable
-    public a = {};
-
-    @Modifiable
-    public b: Array<string> = [];
-
-    @Modifiable
-    public c: number | undefined = undefined;
-}
-
-class CmdModifiableDouble extends ExampleUndoableCmd {
-    @Modifiable
-    public a: number;
-
-    @Modifiable
-    public b: boolean;
-
-    public c: string;
-
-    public constructor() {
-        super();
-        this.a = 0;
-        this.b = false;
-        this.c = "foo";
-    }
-}
+import {CmdModifiableDouble, CmdModifiableDouble2, CmdModifiableDouble3} from "../StubCmd";
 
 describe("using a modifiable decorator on commands", () => {
     describe("and an undoable command", () => {
@@ -46,10 +13,11 @@ describe("using a modifiable decorator on commands", () => {
         });
 
         test("can modify one property with @Modifiable", () => {
-            modifyCmdAttributes(cmd, {
+            const res = modifyCmdAttributes(cmd, {
                 a: 21
             });
 
+            expect(res).toBeTruthy();
             expect(cmd.a).toBe(21);
             expect(cmd.b).toBeFalsy();
             expect(cmd.c).toBe("foo");
@@ -88,6 +56,24 @@ describe("using a modifiable decorator on commands", () => {
             expect(cmd.c).toBe("foo");
         });
 
+        test("does nothing since same value (1 attr)", () => {
+            const res = modifyCmdAttributes(cmd, {
+                a: 0
+            });
+
+            expect(res).toBeFalsy();
+        });
+
+        test("does nothing since same value (1 attr)", () => {
+            const res = modifyCmdAttributes(cmd, {
+                a: 0,
+                b: true
+            });
+
+            expect(res).toBeTruthy();
+            expect(cmd.b).toBeTruthy();
+        });
+
         test("cannot modify one non-existing property", () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             modifyCmdAttributes(cmd as any, {
@@ -119,19 +105,6 @@ describe("using a modifiable decorator on commands", () => {
             test("get modifiable properties does not include the ones badly typed", () => {
                 expect(getModifiableCmdAttributes(new CmdModifiableDouble3())).toStrictEqual({});
             });
-        });
-    });
-
-    describe("and an non-done command", () => {
-        test("cannot modify one property with @Modifiable", () => {
-            const cmd = new CmdModifiableDouble();
-            modifyCmdAttributes(cmd, {
-                a: 21,
-                b: true
-            });
-
-            expect(cmd.a).toBe(0);
-            expect(cmd.b).toBeFalsy();
         });
     });
 

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -1,7 +1,7 @@
-import {getModifiableCmdAttributes, isCmdModifiable, Modifiable, modifyCmdAttributes} from "../../../src/api/command/ModifiableCommand";
+import {getModifiableCmdAttributes, isCmdModifiable, Modifiable, modifyCmdAttributes} from "../../../src/interacto";
 import {beforeEach, describe, expect, test} from "@jest/globals";
 import {ExampleUndoableCmd, StubCmd} from "../StubCmd";
-import type {UndoableCommand} from "../../../src/impl/command/UndoableCommand";
+import type {UndoableCommand} from "../../../src/interacto";
 
 class CmdModifiableDouble2 extends StubCmd {
     @Modifiable

--- a/test/command/library/ModifiableCommand.test.ts
+++ b/test/command/library/ModifiableCommand.test.ts
@@ -121,6 +121,19 @@ describe("using a modifiable decorator on commands", () => {
         });
     });
 
+    describe("and an non-done command", () => {
+        test("cannot modify one property with @Modifiable", () => {
+            const cmd = new CmdModifiableDouble();
+            modifyCmdAttributes(cmd, {
+                a: 21,
+                b: true
+            });
+
+            expect(cmd.a).toBe(0);
+            expect(cmd.b).toBeFalsy();
+        });
+    });
+
     describe("and an non-undoable command", () => {
         let cmd: CmdModifiableDouble2;
 

--- a/test/undo/TreeUndoHistory.test.ts
+++ b/test/undo/TreeUndoHistory.test.ts
@@ -1118,7 +1118,7 @@ describe("using a tree undo history", () => {
         beforeEach(() => {
             cmd = new CmdModifiableDouble();
             cmd.done();
-            history = new TreeUndoHistoryImpl();
+            history = new TreeUndoHistoryImpl(true, true);
             history.add(new CmdModifiableDouble3());
             history.add(cmd);
             // A - B*
@@ -1212,6 +1212,19 @@ describe("using a tree undo history", () => {
                 a: 0
             });
             expect(history.size()).toBe(2);
+        });
+
+        test("no effect when modified command equals an sibling one", () => {
+            history.applyModifiedAttributesOn(history.root.children[0].children[0].id, {
+                a: 10
+            });
+            // A - B( 0)
+            //   \ B(10)'*
+            history.applyModifiedAttributesOn(history.root.children[0].children[0].id, {
+                a: 10
+            });
+            expect(history.size()).toBe(3);
+            expect(history.root.children[0].children).toHaveLength(2);
         });
     });
 });

--- a/test/undo/TreeUndoHistory.test.ts
+++ b/test/undo/TreeUndoHistory.test.ts
@@ -19,6 +19,7 @@ import {TestScheduler} from "rxjs/testing";
 import type {TreeUndoHistory} from "../../src/api/undo/TreeUndoHistory";
 import type {Undoable} from "../../src/api/undo/Undoable";
 import type {MockProxy} from "jest-mock-extended";
+import {CmdModifiableDouble, CmdModifiableDouble3, StubUndoableCmd} from "../command/StubCmd";
 
 interface Undoable4Test extends Undoable {
     foo: number;
@@ -1082,6 +1083,143 @@ describe("using a tree undo history", () => {
             expect(history.getLastUndo()).toBe(undoableC);
             expect(history.getLastRedo()).toBe(undoableD);
             expect(history.size()).toBe(5);
+        });
+    });
+
+    describe("getModifiableAttributesOf", () => {
+        let modCmd: CmdModifiableDouble;
+
+        beforeEach(() => {
+            history = new TreeUndoHistoryImpl();
+            modCmd = new CmdModifiableDouble();
+            // execute the command to make its attributes available
+            modCmd.done();
+            history.add(modCmd);
+        });
+
+        test("returns empty object when id does not exist", () => {
+            expect(history.getModifiableAttributesOf(2)).toEqual({});
+        });
+
+        test("returns the current modifiable attributes of the targeted undoable", () => {
+            const attrs = history.getModifiableAttributesOf(0);
+            expect(Object.keys(attrs)).toContain("a");
+            expect(Object.keys(attrs)).toContain("b");
+            expect(attrs).toEqual({
+                a: modCmd.a,
+                b: modCmd.b
+            });
+        });
+    });
+
+    describe("using a standard tree history storing modifiable commands", () => {
+        let cmd: CmdModifiableDouble;
+
+        beforeEach(() => {
+            cmd = new CmdModifiableDouble();
+            cmd.done();
+            history = new TreeUndoHistoryImpl();
+            history.add(new CmdModifiableDouble3());
+            history.add(cmd);
+            // A - B*
+        });
+
+        test("can modify the lastest modifiable command with no following command", () => {
+            history.applyModifiedAttributesOn(history.currentNode.id, {
+                a: 42
+            });
+
+            // A - B
+            //   \ B'*
+            expect(history.size()).toBe(3);
+            expect(history.root.children.length).toBe(1);
+            expect(history.root.children[0].children.length).toBe(2);
+            expect(history.currentNode.undoable).toBe(history.root.children[0].children[1].undoable);
+            expect(history.getLastUndo()).toBe(history.currentNode.undoable);
+            expect(history.getLastRedo()).toBeUndefined();
+            expect((history.currentNode.undoable as CmdModifiableDouble).re).toBe(1);
+        });
+
+        test("can modify the lastest modifiable command and re-execute the line undoables that follow", () => {
+            history.add(new StubUndoableCmd());
+            // A - B - C*
+
+            history.applyModifiedAttributesOn(history.root.children[0].children[0].id, {
+                a: 42
+            });
+            // A - B  - C
+            //   \ B'* - C'
+
+            expect(history.size()).toBe(5);
+            expect(history.root.children.length).toBe(1);
+            expect(history.root.children[0].children.length).toBe(2);
+            expect(history.root.children[0].children[0].children.length).toBe(1);
+            expect(history.root.children[0].children[1].children.length).toBe(1);
+            expect(history.root.children[0].children[0].children[0].undoable).toBeInstanceOf(StubUndoableCmd);
+            expect(history.root.children[0].children[1].children[0].undoable).toBeInstanceOf(StubUndoableCmd);
+            expect(history.root.children[0].children[0].undoable).toBeInstanceOf(CmdModifiableDouble);
+            expect(history.root.children[0].children[1].undoable).toBeInstanceOf(CmdModifiableDouble);
+            expect(history.currentNode.undoable).toBe(history.root.children[0].children[1].undoable);
+        });
+
+        test("can modify the lastest modifiable command and re-execute the tree undoables that follow", () => {
+            history.add(new StubUndoableCmd());
+            history.undo();
+            history.add(new CmdModifiableDouble());
+            // A - B - C
+            //       \ D*
+
+            history.applyModifiedAttributesOn(history.root.children[0].children[0].id, {
+                a: 42
+            });
+            // A - B  - C
+            //        \ D
+            //   \ B'* - C'
+            //        \ D'
+
+            expect(history.size()).toBe(7);
+            expect(history.root.children.length).toBe(1);
+            expect(history.root.children[0].children.length).toBe(2);
+            expect(history.root.children[0].children[0].children.length).toBe(2);
+            expect(history.root.children[0].children[1].children.length).toBe(2);
+            expect(history.root.children[0].children[0].children[0].children.length).toBe(0);
+            expect(history.root.children[0].children[0].children[1].children.length).toBe(0);
+            expect(history.root.children[0].children[1].children[0].children.length).toBe(0);
+            expect(history.root.children[0].children[1].children[1].children.length).toBe(0);
+            expect(history.root.children[0].children[0].children[1].undoable).toBeInstanceOf(CmdModifiableDouble);
+            expect(history.root.children[0].children[1].children[1].undoable).toBeInstanceOf(CmdModifiableDouble);
+            expect(history.root.children[0].children[0].children[0].undoable).toBeInstanceOf(StubUndoableCmd);
+            expect(history.root.children[0].children[1].children[0].undoable).toBeInstanceOf(StubUndoableCmd);
+            expect(history.root.children[0].children[0].undoable).toBeInstanceOf(CmdModifiableDouble);
+            expect(history.root.children[0].children[1].undoable).toBeInstanceOf(CmdModifiableDouble);
+            expect(history.currentNode.undoable).toBe(history.root.children[0].children[1].undoable);
+        });
+
+        test("no effect when the changes do not change the single targeted attribute", () => {
+            history.applyModifiedAttributesOn(history.currentNode.id, {
+                a: 0
+            });
+
+            // A - B*
+            expect(history.size()).toBe(2);
+            expect(history.root.children[0].children.length).toBe(1);
+            expect(history.currentNode.undoable).toBe(history.root.children[0].children[0].undoable);
+        });
+
+        test("no effect when trying to modify the root", () => {
+            // A - B*
+            history.applyModifiedAttributesOn(history.root.id, {
+                a: 0
+            });
+            expect(history.size()).toBe(2);
+        });
+
+        test("no effect when trying to modify the root", () => {
+            // A - B*
+            history.applyModifiedAttributesOn(history.root.id, {
+                a: 0
+            });
+            expect(history.size()).toBe(2);
         });
     });
 });

--- a/test/undo/TreeUndoHistory.test.ts
+++ b/test/undo/TreeUndoHistory.test.ts
@@ -1218,8 +1218,9 @@ describe("using a tree undo history", () => {
             history.applyModifiedAttributesOn(history.root.children[0].children[0].id, {
                 a: 10
             });
-            // A - B( 0)
-            //   \ B(10)'*
+            history.goTo(history.root.children[0].children[0].id);
+            // A - B( 0)*
+            //   \ B(10)'
             history.applyModifiedAttributesOn(history.root.children[0].children[0].id, {
                 a: 10
             });

--- a/test/undo/TreeUndoHistory.test.ts
+++ b/test/undo/TreeUndoHistory.test.ts
@@ -1098,14 +1098,14 @@ describe("using a tree undo history", () => {
         });
 
         test("returns empty object when id does not exist", () => {
-            expect(history.getModifiableAttributesOf(2)).toEqual({});
+            expect(history.getModifiableAttributesOf(2)).toStrictEqual({});
         });
 
         test("returns the current modifiable attributes of the targeted undoable", () => {
             const attrs = history.getModifiableAttributesOf(0);
             expect(Object.keys(attrs)).toContain("a");
             expect(Object.keys(attrs)).toContain("b");
-            expect(attrs).toEqual({
+            expect(attrs).toStrictEqual({
                 a: modCmd.a,
                 b: modCmd.b
             });
@@ -1132,8 +1132,8 @@ describe("using a tree undo history", () => {
             // A - B
             //   \ B'*
             expect(history.size()).toBe(3);
-            expect(history.root.children.length).toBe(1);
-            expect(history.root.children[0].children.length).toBe(2);
+            expect(history.root.children).toHaveLength(1);
+            expect(history.root.children[0].children).toHaveLength(2);
             expect(history.currentNode.undoable).toBe(history.root.children[0].children[1].undoable);
             expect(history.getLastUndo()).toBe(history.currentNode.undoable);
             expect(history.getLastRedo()).toBeUndefined();
@@ -1151,10 +1151,10 @@ describe("using a tree undo history", () => {
             //   \ B'* - C'
 
             expect(history.size()).toBe(5);
-            expect(history.root.children.length).toBe(1);
-            expect(history.root.children[0].children.length).toBe(2);
-            expect(history.root.children[0].children[0].children.length).toBe(1);
-            expect(history.root.children[0].children[1].children.length).toBe(1);
+            expect(history.root.children).toHaveLength(1);
+            expect(history.root.children[0].children).toHaveLength(2);
+            expect(history.root.children[0].children[0].children).toHaveLength(1);
+            expect(history.root.children[0].children[1].children).toHaveLength(1);
             expect(history.root.children[0].children[0].children[0].undoable).toBeInstanceOf(StubUndoableCmd);
             expect(history.root.children[0].children[1].children[0].undoable).toBeInstanceOf(StubUndoableCmd);
             expect(history.root.children[0].children[0].undoable).toBeInstanceOf(CmdModifiableDouble);
@@ -1178,14 +1178,14 @@ describe("using a tree undo history", () => {
             //        \ D'
 
             expect(history.size()).toBe(7);
-            expect(history.root.children.length).toBe(1);
-            expect(history.root.children[0].children.length).toBe(2);
-            expect(history.root.children[0].children[0].children.length).toBe(2);
-            expect(history.root.children[0].children[1].children.length).toBe(2);
-            expect(history.root.children[0].children[0].children[0].children.length).toBe(0);
-            expect(history.root.children[0].children[0].children[1].children.length).toBe(0);
-            expect(history.root.children[0].children[1].children[0].children.length).toBe(0);
-            expect(history.root.children[0].children[1].children[1].children.length).toBe(0);
+            expect(history.root.children).toHaveLength(1);
+            expect(history.root.children[0].children).toHaveLength(2);
+            expect(history.root.children[0].children[0].children).toHaveLength(2);
+            expect(history.root.children[0].children[1].children).toHaveLength(2);
+            expect(history.root.children[0].children[0].children[0].children).toHaveLength(0);
+            expect(history.root.children[0].children[0].children[1].children).toHaveLength(0);
+            expect(history.root.children[0].children[1].children[0].children).toHaveLength(0);
+            expect(history.root.children[0].children[1].children[1].children).toHaveLength(0);
             expect(history.root.children[0].children[0].children[1].undoable).toBeInstanceOf(CmdModifiableDouble);
             expect(history.root.children[0].children[1].children[1].undoable).toBeInstanceOf(CmdModifiableDouble);
             expect(history.root.children[0].children[0].children[0].undoable).toBeInstanceOf(StubUndoableCmd);
@@ -1202,16 +1202,8 @@ describe("using a tree undo history", () => {
 
             // A - B*
             expect(history.size()).toBe(2);
-            expect(history.root.children[0].children.length).toBe(1);
+            expect(history.root.children[0].children).toHaveLength(1);
             expect(history.currentNode.undoable).toBe(history.root.children[0].children[0].undoable);
-        });
-
-        test("no effect when trying to modify the root", () => {
-            // A - B*
-            history.applyModifiedAttributesOn(history.root.id, {
-                a: 0
-            });
-            expect(history.size()).toBe(2);
         });
 
         test("no effect when trying to modify the root", () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "moduleResolution": "node",
     "module": "ES2022",
     "pretty": true,


### PR DESCRIPTION
Interacto now supports undoable commands that can be modified, through a dedicated annotation.
For the moment, only the tree-based history supports this new feature.